### PR TITLE
update espresso to 3.6.1

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,7 +6,7 @@ object Versions {
     const val dokkaPlugin = "1.9.20"
 
     const val recyclerView = "1.2.1"
-    const val espresso = "3.4.0"
+    const val espresso = "3.6.1"
     const val uiautomator = "2.2.0"
     const val accessibility = "4.0.0"
     const val hamcrestCore = "2.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.3.2"
 atomicfu = "0.24.0"
+guava = "33.2.1-android"
 kotlin = "2.0.0"
 compose = "1.6.7"
 compose-compiler = "1.5.4"
@@ -29,6 +30,7 @@ uiTestJunit4Android = "1.6.8"
 androidx-ui-test-junit4-android = { module = "androidx.compose.ui:ui-test-junit4-android", version.ref = "uiTestJunit4Android" }
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "uiTestJunit4Android" }
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }

--- a/ultron-android/build.gradle.kts
+++ b/ultron-android/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(Libs.kotlinReflect)
     implementation(Libs.kotlinStdlib)
     implementation(Libs.recyclerView)
+    implementation(libs.guava)
     api(Libs.espressoCore)
     api(Libs.espressoContrib)
     api(Libs.espressoWeb)

--- a/ultron-android/src/main/kotlin/com/atiurin/ultron/custom/espresso/base/UltronViewFinder.kt
+++ b/ultron-android/src/main/kotlin/com/atiurin/ultron/custom/espresso/base/UltronViewFinder.kt
@@ -9,12 +9,6 @@ import androidx.test.espresso.DataInteraction
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewInteraction
-import androidx.test.espresso.core.internal.deps.guava.base.Joiner
-import androidx.test.espresso.core.internal.deps.guava.base.Preconditions
-import androidx.test.espresso.core.internal.deps.guava.base.Predicate
-import androidx.test.espresso.core.internal.deps.guava.collect.Iterables
-import androidx.test.espresso.core.internal.deps.guava.collect.Iterators
-import androidx.test.espresso.core.internal.deps.guava.collect.Lists
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.util.EspressoOptional
 import androidx.test.espresso.util.TreeIterables
@@ -25,6 +19,12 @@ import com.atiurin.ultron.extensions.getTargetMatcher
 import com.atiurin.ultron.extensions.getViewMatcher
 import com.atiurin.ultron.extensions.simpleClassName
 import com.atiurin.ultron.utils.runOnUiThread
+import com.google.common.base.Joiner
+import com.google.common.base.Preconditions
+import com.google.common.base.Predicate
+import com.google.common.collect.Iterables
+import com.google.common.collect.Iterators
+import com.google.common.collect.Lists
 import org.hamcrest.Matcher
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicReference


### PR DESCRIPTION
- add usage of guava lib directly. probably, it will by deleted in future releases