### PR TITLE
Release 2.6.3

### DIFF
--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -7,6 +7,13 @@ title: Release notes
 
 This page summarizes Ultron releases from 2.5.1 onward. Older releases are available on the [GitHub Releases](https://github.com/open-tool/ultron/releases) page.
 
+## Version 2.6.3
+
+_Released June 15, 2026_ · [GitHub release](https://github.com/open-tool/ultron/releases/tag/2.6.3) · [Full changelog](https://github.com/open-tool/ultron/compare/2.6.2...2.6.3)
+
+- Fixed Compose Multiplatform 1.10 test API compatibility for `runUltronUiTest` and desktop Compose wrappers.
+- Added automated release preparation, tag-driven Maven Central publication, GitHub Release creation, and Telegram announcements.
+
 ## Version 2.6.2
 
 _Released October 29, 2025_ · [GitHub release](https://github.com/open-tool/ultron/releases/tag/2.6.2) · [Full changelog](https://github.com/open-tool/ultron/compare/2.6.1...2.6.2)

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ kotlin.native.cacheKind=none
 
 GROUP=com.atiurin
 POM_ARTIFACT_ID=ultron
-VERSION_NAME=2.6.2
+VERSION_NAME=2.6.3


### PR DESCRIPTION
## Release 2.6.3

Merging this PR authorizes automated publication for Ultron 2.6.3.

After merge, CI will:
- create tag `2.6.3` on the merge commit
- publish Ultron artifacts to Maven Central
- create the GitHub Release
- send the Telegram announcement

### Reviewed release notes

- Fixed Compose Multiplatform 1.10 test API compatibility for `runUltronUiTest` and desktop Compose wrappers.
- Added automated release preparation, tag-driven Maven Central publication, GitHub Release creation, and Telegram announcements.

### Changelog

https://github.com/open-tool/ultron/compare/2.6.2...2.6.3

### Checklist

- [x] `VERSION_NAME` is `2.6.3`
- [x] `docs/docs/release-notes.md` contains reviewed highlights
- [x] Release guard workflow should validate this PR
- [ ] Merge approval is intentional; no separate publish approval will be requested
