### PR TITLE
Release 2.6.4

### DIFF
--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -7,6 +7,12 @@ title: Release notes
 
 This page summarizes Ultron releases from 2.5.1 onward. Older releases are available on the [GitHub Releases](https://github.com/open-tool/ultron/releases) page.
 
+## Version 2.6.4
+
+_Released August 15, 2026_ · [GitHub release](https://github.com/open-tool/ultron/releases/tag/2.6.4) · [Full changelog](https://github.com/open-tool/ultron/compare/2.6.3...2.6.4)
+
+- TODO: Replace with reviewed release highlight.
+
 ## Version 2.6.3
 
 _Released June 15, 2026_ · [GitHub release](https://github.com/open-tool/ultron/releases/tag/2.6.3) · [Full changelog](https://github.com/open-tool/ultron/compare/2.6.2...2.6.3)

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -11,7 +11,9 @@ This page summarizes Ultron releases from 2.5.1 onward. Older releases are avail
 
 _Released August 15, 2026_ · [GitHub release](https://github.com/open-tool/ultron/releases/tag/2.6.4) · [Full changelog](https://github.com/open-tool/ultron/compare/2.6.3...2.6.4)
 
-- TODO: Replace with reviewed release highlight.
+- Fixed UiAutomator backend regressions: `legacySetText` no longer crashes on editable fields, `UltronConfig.UiAutomator.uiDevice` is initialized lazily, and hierarchy dumps are more resilient. [#138](https://github.com/open-tool/ultron/pull/138)
+- Fixed Allure screenshot attachment to fail gracefully instead of attaching an empty file when both screenshoters fail.
+- Updated AndroidX Test dependencies: Espresso 3.7.0, androidx.test 1.7.0, junit-ext 1.3.0. [#136](https://github.com/open-tool/ultron/pull/136)
 
 ## Version 2.6.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ kotlin.native.cacheKind=none
 
 GROUP=com.atiurin
 POM_ARTIFACT_ID=ultron
-VERSION_NAME=2.6.3
+VERSION_NAME=2.6.4


### PR DESCRIPTION
## Release 2.6.4

Merging this PR authorizes automated publication for Ultron 2.6.4.

After merge, CI will:
- create tag `2.6.4` on the merge commit
- publish Ultron artifacts to Maven Central
- create the GitHub Release
- send the Telegram announcement

### Reviewed release notes

Please replace every TODO highlight in `docs/docs/release-notes.md` before merging.

### Changelog

https://github.com/open-tool/ultron/compare/2.6.3...2.6.4

### Checklist

- [x] `VERSION_NAME` is `2.6.4`
- [x] `docs/docs/release-notes.md` contains reviewed highlights
- [x] Release guard workflow is green
- [x] Merge approval is intentional; no separate publish approval will be requested
