### PR TITLE
Release 2.6.5

### DIFF
--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -7,6 +7,13 @@ title: Release notes
 
 This page summarizes Ultron releases from 2.5.1 onward. Older releases are available on the [GitHub Releases](https://github.com/open-tool/ultron/releases) page.
 
+## Version 2.6.5
+
+_Released August 15, 2026_ · [GitHub release](https://github.com/open-tool/ultron/releases/tag/2.6.5) · [Full changelog](https://github.com/open-tool/ultron/compare/2.6.4...2.6.5)
+
+- Retry allowed config. [#137](https://github.com/open-tool/ultron/pull/137)
+- Add interactive release note review behind --control-desc.
+
 ## Version 2.6.4
 
 _Released August 15, 2026_ · [GitHub release](https://github.com/open-tool/ultron/releases/tag/2.6.4) · [Full changelog](https://github.com/open-tool/ultron/compare/2.6.3...2.6.4)

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ kotlin.native.cacheKind=none
 
 GROUP=com.atiurin
 POM_ARTIFACT_ID=ultron
-VERSION_NAME=2.6.4
+VERSION_NAME=2.6.5


### PR DESCRIPTION
## Release 2.6.5

Merging this PR authorizes automated publication for Ultron 2.6.5.

After merge, CI will:
- create tag `2.6.5` on the merge commit
- publish Ultron artifacts to Maven Central
- create the GitHub Release
- send the Telegram announcement

### Reviewed release notes

Highlights in `docs/docs/release-notes.md` are drafted from the pull requests merged
since 2.6.4. Rewrite them into user-facing wording before merging: the same text is
published to the docs site, the GitHub Release body, and the Telegram announcement.

### Changelog

https://github.com/open-tool/ultron/compare/2.6.4...2.6.5

### Checklist

- [ ] `VERSION_NAME` is `2.6.5`
- [ ] `docs/docs/release-notes.md` contains reviewed highlights
- [ ] Release guard workflow is green
- [ ] Merge approval is intentional; no separate publish approval will be requested
